### PR TITLE
Support multiple GPG keys

### DIFF
--- a/KeepassPinentry/Pinentry.cs
+++ b/KeepassPinentry/Pinentry.cs
@@ -12,6 +12,7 @@ namespace KeepassPinentry
 
         public void Handle(TextReader reader, TextWriter writer)
         {
+            // See https://www.gnupg.org/documentation/manuals/assuan.pdf
             string keyInfo = "";
 
             writer.WriteLine("OK Ready.");
@@ -53,8 +54,16 @@ namespace KeepassPinentry
                     keyInfo = args == "--clear" ? "" : args;
 
                 } else if (line.StartsWith("GETPIN")) {
-                    writer.WriteLine("D " + PasswordFetcher(keyInfo));
-
+                    try
+                    {
+                        writer.WriteLine("D " + PasswordFetcher(keyInfo));
+                    }
+                    catch (EntryDBException e)
+                    {
+                        // https://dev.gnupg.org/source/libgpg-error/browse/master/src/err-codes.h.in
+                        // https://dev.gnupg.org/source/libgpg-error/browse/master/doc/errorref.txt
+                        writer.WriteLine($"ERR 86 {e.Message}"); // GPG_ERR_PIN_ENTRY
+                    }
                 } else {
                     // do nothing
                 }


### PR DESCRIPTION
This feature relies on getting a key ID from `SETKEYINFO`, so I assume it only works when `--no-allow-external-cache` is not set as a GPG agent option. This seems to be a reliable way to get a key ID except for [this](https://dev.gnupg.org/T4522) case. One aspect I am unsure of is what determines that format of the ID provided by the agent. The [documentation](https://dev.gnupg.org/source/pinentry/browse/master/doc/pinentry.texi$585) states that it could be in 3 different forms. In practice, for me, it has used the `n/key-grip` format. To help the user figure out the exact value, a balloon notification with the key info string is shown if a matching entry cannot be found.

When the key info is available, the entry is looked up by comparing the username to the key info. Due to the nature of the key ID, it seems unlikely that there'll be a false positive match for some other unrelated entry. I figured allowing the title to be anything is nice for flexibility, but requiring "GPG" in the title too could be implemented if desired.

If for some reason the key info is cleared, the plugin instead looks up an entry by title using "GPG" as the search string. Then, it looks for the entry whose username is "default" (case-insensitive). An existing entry could be set as default by the user by using a password field reference for the default entry.

Some error handling has been added so that the GPG agent doesn't hang waiting for a response if the plugin is unable to find a suitable entry or crashes before the pin can be sent to the agent.